### PR TITLE
test_server.py: add test for notification limit

### DIFF
--- a/fire/api/services.py
+++ b/fire/api/services.py
@@ -16,6 +16,10 @@ class CustomSQLAlchemyService(SQLAlchemyService):
         table_name = self.__model__.__table__.name
         return self.get(id) or self.not_found("{}[id={}]".format(table_name, id))
 
+    def clone(self, obj):
+        attributes = {k: v for (k, v) in obj.__dict__.items() if not k.startswith("_") and k != "id"}
+        return self.create(**attributes)
+
 class UserService(CustomSQLAlchemyService):
     __model__ = models.User
 

--- a/tests/fire_tests/api/test_server.py
+++ b/tests/fire_tests/api/test_server.py
@@ -70,6 +70,29 @@ class TestFireApiServer(unittest.TestCase):
         notifications = res.body["data"]
         self.assertEqual(len(notifications), 6)
 
+    def add_dummy_user(self, n):
+        "Helper function for test_notification_limit()."
+        new_user = {
+            "name": "dummy {}".format(n),
+            "address": "Cicely, Alaska",
+            "gender": "female",
+            "email": "dummy{}@mail.com".format(n),
+        }
+        res = self.request("POST", '/newUserRequests', {"user": new_user})
+        url = '/newUserRequests/{}/acceptation'.format(res.body["data"]["id"])
+        self.request("POST", url, user="joel")
+
+    def test_notification_limit(self):
+        expected_limit = 50  # maximum notifications reported
+        # Add more than the expected limit.
+        for i in range(expected_limit + 10):
+            self.add_dummy_user(i)
+        # Get all notifications and see if we only get the expected limit.
+        res = self.request("GET", '/notifications', user="joel")
+        self.assertEqual(res.status, 200, res)
+        notifications = res.body["data"]
+        self.assertEqual(len(notifications), expected_limit)
+
     ### New User Requests
 
     def test_get_new_user_requests_as_admin(self):


### PR DESCRIPTION
Closes #19.

It adds a single test in `test_server.py` that creates (and accepts) more users than the limit of notifications (50), so more notifications than the limit will be created. It then reads all the notifications, and asserts that it only retrieves that limit.